### PR TITLE
Add support for custom config files

### DIFF
--- a/sub_pre_commit/cli.py
+++ b/sub_pre_commit/cli.py
@@ -17,6 +17,11 @@ def main(
         None,
         help="List of files to pass to sub pre-commit.",
     ),
+    config_file: str = typer.Option(
+        ".pre-commit-config.yaml",
+        "--config-file", "-c",
+        help="Path to the configuration file for sub pre-commit.",
+    ),
 ) -> None:
     relevant_files = []
     if files:  # No files mean --all-files was used
@@ -36,6 +41,8 @@ def main(
     cmd = [
         "sub-pre-commit-run",
         "run",
+        "--config-file",
+        config_file,
     ]
     if files:
         cmd.extend([


### PR DESCRIPTION
This change should include support for custom config files. Hence, we could name our sub config files "foo.yaml" and they won't be picked up by `pre-commit run -a` if executed from the subfolder. 