### PR TITLE
Bump up python and typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["David Danier <danier@team23.de>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.9"
-typer = "^0.9.0"
+python = "^3.10"
+typer = "^0.19.1"
 pre-commit = "4.3.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Python 3.9 is close to [EOL](https://devguide.python.org/versions/). This PR bumps up Python version and also [dependency package (typer)](https://typer.tiangolo.com/release-notes/) to the latest